### PR TITLE
Feature- search from the trip status table

### DIFF
--- a/models/students_fieldtripsModel/index.js
+++ b/models/students_fieldtripsModel/index.js
@@ -25,7 +25,7 @@ const searchStudentStatuses = async (tripId, query, perPage) => {
   const searchedStudentsPerPageResult = await db("students_field_trips")
     .join('students', 'students_field_trips.student_id', 'students.id')
     .select('students.*',
-      'students_field_trips.*', // students_field_trips.id overwrites student.id
+      'students_field_trips.*',
       'students.id as student_id'
     )
     .where({field_trip_id: tripId})
@@ -70,17 +70,28 @@ const getStudentStatusesByTripIdPaginated = async (
       .where({ field_trip_id: tripId })
       .orderBy(sortBy, direction).offset(offset).limit(perPage);
 
-    // getting the count
+    const incompleteStudentStatus = await db("students_field_trips")
+      .join('students', 'students_field_trips.student_id', 'students.id')
+      .select('students.*',
+        'students_field_trips.*',
+        'students.id as student_id'
+      )
+      .where({ field_trip_id: tripId })
+      .andWhere('going_status', '=', 'false');
+    const statusIncompleteCount = incompleteStudentStatus.length;
+    console.log('statusIncompleteCount:', statusIncompleteCount);
+
+    // getting total count of students in the students_field_trips table
     const countObject = await db("students_field_trips")
       .where({ field_trip_id: tripId }).count().first();
     const totalCount = Number(countObject.count);
 
     console.log('totalStudents', totalCount);
-
     const totalPages = Math.ceil(totalCount / Number(perPage));
 
     return {
       totalCount,
+      statusIncompleteCount,
       completeStudentStatusesSorted,
       totalPages
     }
@@ -89,7 +100,7 @@ const getStudentStatusesByTripIdPaginated = async (
     const searchedStudentStatus = await db("students_field_trips")
       .join('students', 'students_field_trips.student_id', 'students.id')
       .select('students.*',
-        'students_field_trips.*', // students_field_trips.id overwrites student.id
+        'students_field_trips.*',
         'students.id as student_id'
       )
       .where({field_trip_id: tripId})
@@ -99,7 +110,7 @@ const getStudentStatusesByTripIdPaginated = async (
     const searchedStudentsPerPageResult = await db("students_field_trips")
       .join('students', 'students_field_trips.student_id', 'students.id')
       .select('students.*',
-        'students_field_trips.*', // students_field_trips.id overwrites student.id
+        'students_field_trips.*',
         'students.id as student_id'
       )
       .where({field_trip_id: tripId})

--- a/routes/students_fieldtrips/index.js
+++ b/routes/students_fieldtrips/index.js
@@ -56,12 +56,14 @@ router.get("/:tripId/statuses", async (req, res) => {
   try {
     const {
       totalCount,
+      statusIncompleteCount,
       completeStudentStatusesSorted,
       totalPages
     } = await db.getStudentStatusesByTripIdPaginated(tripId, page, perPage, sortBy, direction, query);
 
     res.status(200).json({
       completeStudentStatusesSorted,
+      statusIncompleteCount,
       totalCount,
       totalPages,
       perPage: Number(perPage)

--- a/routes/students_fieldtrips/index.js
+++ b/routes/students_fieldtrips/index.js
@@ -16,6 +16,28 @@ router.get("/", async (req, res) => {
   }
 });
 
+router.get("/:tripId/statuses/search", async (req, res) => {
+  const { tripId } = req.params;
+  const {
+    query = ''
+  } = req.query;
+
+  try {
+    const {
+      searchedStudentStatus,
+    } = await db.searchStudentStatuses(tripId, query);
+
+    res.status(200).json({
+      searchedStudentStatus,
+    });
+  } catch (error) {
+    res.status(500).json({
+      message: `error getting student for trip id: ${tripId}`,
+      error: error
+    });
+  }
+});
+
 router.get("/:tripId/statuses", async (req, res) => {
   const { tripId } = req.params;
   const {

--- a/routes/students_fieldtrips/index.js
+++ b/routes/students_fieldtrips/index.js
@@ -19,16 +19,21 @@ router.get("/", async (req, res) => {
 router.get("/:tripId/statuses/search", async (req, res) => {
   const { tripId } = req.params;
   const {
-    query = ''
+    query = '',
+    perPage = 5,
   } = req.query;
 
   try {
     const {
       searchedStudentStatus,
-    } = await db.searchStudentStatuses(tripId, query);
+      countOnSearchResult,
+      totalPagesOnSearchResult
+    } = await db.searchStudentStatuses(tripId, query, perPage);
 
     res.status(200).json({
       searchedStudentStatus,
+      countOnSearchResult,
+      totalPagesOnSearchResult
     });
   } catch (error) {
     res.status(500).json({
@@ -44,7 +49,8 @@ router.get("/:tripId/statuses", async (req, res) => {
     page = 1,
     perPage = 5,
     sortBy = 'last_name',
-    direction = 'asc'
+    direction = 'asc',
+    query = ''
   } = req.query;
 
   try {
@@ -52,7 +58,7 @@ router.get("/:tripId/statuses", async (req, res) => {
       totalCount,
       completeStudentStatusesSorted,
       totalPages
-    } = await db.getStudentStatusesByTripIdPaginated(tripId, page, perPage, sortBy, direction);
+    } = await db.getStudentStatusesByTripIdPaginated(tripId, page, perPage, sortBy, direction, query);
 
     res.status(200).json({
       completeStudentStatusesSorted,


### PR DESCRIPTION
This PR (related to the Frontend PR#) implements the following feature(s):

- search student from the trip status table on keydown
-  correct count per page and total pages (for pagination consistency) is sent to FE
- add query/perPage params to students_fieldtrips search and statuses route endpoints & update the json response
- send count of incomplete statuses to FE for the trip status table