### PR TITLE
bug fix: student trip status search feature

### DIFF
--- a/models/students_fieldtripsModel/index.js
+++ b/models/students_fieldtripsModel/index.js
@@ -19,8 +19,10 @@ const searchStudentStatuses = async (tripId, query, perPage) => {
       'students.id as student_id'
     )
     .where({field_trip_id: tripId})
-    .andWhereRaw("LOWER(first_name) LIKE '%' || LOWER(?) || '%' ", query)
-    .orWhereRaw("LOWER(last_name) LIKE '%' || LOWER(?) || '%' ", query)
+    .where((builder)=> {
+      builder.where("first_name", "ilike", `%${query}%`)
+        .orWhere("last_name", "ilike", `%${query}%`);
+    });
 
   const searchedStudentsPerPageResult = await db("students_field_trips")
     .join('students', 'students_field_trips.student_id', 'students.id')
@@ -29,8 +31,10 @@ const searchStudentStatuses = async (tripId, query, perPage) => {
       'students.id as student_id'
     )
     .where({field_trip_id: tripId})
-    .andWhereRaw("LOWER(first_name) LIKE '%' || LOWER(?) || '%' ", query)
-    .orWhereRaw("LOWER(last_name) LIKE '%' || LOWER(?) || '%' ", query)
+    .where((builder)=> {
+      builder.where("first_name", "ilike", `%${query}%`)
+        .orWhere("last_name", "ilike", `%${query}%`);
+    })
     .limit(perPage);
 
   // to keep in mind:


### PR DESCRIPTION
This PR fixes incorrect searches from the trip status table. The search query was still finding students not matched to the tripId. This appears to be due to the wrong order and use of additional `knex().where()` functions, i.e. `andWhere()`, `orWhere()`.

Solution:
- add correct knex query for the trip status search functionality
- add the chained queries inside a function passed in `.where()` .

Additional Notes:
- used `"ilike"` to change the search query to lowercase instead of `LOWER()` from SQL